### PR TITLE
Improved LaTeX output

### DIFF
--- a/cqt_anyons/circuit.py
+++ b/cqt_anyons/circuit.py
@@ -117,7 +117,7 @@ class AnyonicCircuit:
                 raise ValueError("Indices and powers must be integers!")
             if ind < 1:
                 raise ValueError(f"sigma_{ind} is not a valid braiding operator! "
-                                 f"The operators indices must be > 1.")
+                                 f"The operators indices must be >= 1.")
             if ind >= self.__nb_anyons:
                 raise ValueError(f"sigma_{ind} is not a valid braiding operator! "
                                  f"The operators indices must be < {self.__nb_anyons}.")

--- a/testing_notebook.ipynb
+++ b/testing_notebook.ipynb
@@ -10,17 +10,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "id": "618b77fa",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<cqt_anyons.circuit.AnyonicCircuit at 0x243cdc3e550>"
+       "<cqt_anyons.circuit.AnyonicCircuit at 0x126ba62bb20>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "id": "cc9b61bd",
    "metadata": {},
    "outputs": [
@@ -54,7 +54,7 @@
        "<Figure size 1116x64.8 with 1 Axes>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "id": "75ced16e",
    "metadata": {},
    "outputs": [
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "id": "b156178e",
    "metadata": {},
    "outputs": [
@@ -96,7 +96,7 @@
        "<IPython.core.display.Latex object>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Now outputs a compact sequence of sigmas using exponents.
Also fixed a typo.

![new_latex](https://user-images.githubusercontent.com/65052452/194881485-196d61cd-ed24-4aa0-b0b3-d940f53f7ecb.png)

Instead of

![old_latex](https://user-images.githubusercontent.com/65052452/194881544-dc1682a9-f574-4115-9f1f-3fe24d0eb44e.png)
