### PR TITLE
fix: reverse history("raw")

### DIFF
--- a/tqsim/circuit.py
+++ b/tqsim/circuit.py
@@ -384,7 +384,7 @@ class AnyonicCircuit:
             raise ValueError('Output should be either: "raw", "sigmas" or "latex"')
 
         if output == "raw":
-            return self.__braids_history
+            return self.__braids_history[::-1]
 
         elif output == "sigmas":
             ret = []


### PR DESCRIPTION
The braid_history should be sent reversed in the history method because they represent matrix multiplication

Resolves #29